### PR TITLE
Add extra channel conditions for Role pinging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ client.on(Events.ThreadCreate, async (channel) => {
                 await timeout(2000);
                 await message.delete();
             }
-            else if (channel.parent && channel.parent.id === '1373797803914166403') {
+            else if (channel.parent && channel.parent.name === 'christmas-event-ideas') {
                 await message.edit(`${BuildRole} ${ServRole}`);
                 await timeout(2000);
                 await message.delete();

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,12 @@ client.on(Events.ThreadCreate, async (channel) => {
             const pingRole = channel.guild.roles.cache.find(
                 (r) => r.name === 'Moderator'
             );
+            const BuildRole = channel.guild.roles.cache.find(
+                (r) => r.name === 'Builder'
+            );
+            const ServRole = channel.guild.roles.cache.find(
+                (r) => r.name === 'Minecraft Server Moderator'
+            )
 
             await timeout(2000);
 
@@ -104,7 +110,17 @@ client.on(Events.ThreadCreate, async (channel) => {
 
             await timeout(2000);
 
-            if (channel.parent && channel.parent.name === 'support') {
+            if (channel.parent && channel.parent.name === 'server-suggestions' || 'server-classifieds') {
+                await message.edit(`${ServRole}`);
+                await timeout(2000);
+                await message.delete();
+            }
+            else if (channel.parent && channel.parent.id === '1373797803914166403') {
+                await message.edit(`${BuildRole} ${ServRole}`);
+                await timeout(2000);
+                await message.delete();
+            }
+            else if (channel.parent && channel.parent.name === 'support') {
                 await message.edit(
                     `Hello <@!${channel.ownerId}>! Someone will help you shortly, please do not ping moderators or other people and just wait for someone to come help. While waiting please check out <#1077195187698274324> to see if it already answers your question.`
                 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,17 +110,20 @@ client.on(Events.ThreadCreate, async (channel) => {
 
             await timeout(2000);
 
-            if (channel.parent && channel.parent.name === 'server-suggestions' || 'server-classifieds') {
+            if (channel.parent && channel.parent.name === 'server-suggestions') {
                 await message.edit(`${ServRole}`);
                 await timeout(2000);
                 await message.delete();
-            }
-            else if (channel.parent && channel.parent.name === 'christmas-event-ideas') {
+            } else if (channel.parent && channel.parent.name === 'server-classifieds') {
+                await message.edit(`${ServRole}`);
+                await timeout(2000);
+                await message.delete();
+            } else if (channel.parent && channel.parent.name === 'christmas-event-ideas'
+            ) {
                 await message.edit(`${BuildRole} ${ServRole}`);
                 await timeout(2000);
                 await message.delete();
-            }
-            else if (channel.parent && channel.parent.name === 'support') {
+            } else if (channel.parent && channel.parent.name === 'support') {
                 await message.edit(
                     `Hello <@!${channel.ownerId}>! Someone will help you shortly, please do not ping moderators or other people and just wait for someone to come help. While waiting please check out <#1077195187698274324> to see if it already answers your question.`
                 );


### PR DESCRIPTION
Added the conditions so the Minecraft Server Moderator role is automatically added to the forum channels relating to the Minecraft server. As well as the Builders role and MC Server Mods being auto-added to a team discussion forum channel.

A suggestion that might help with the bot not building, as it's what I had to do to get the bot to run in my dev environment using my test bot. I had to run `npm install --save-dev cross-env` in my terminal, which created a package-lock.json file (not included in this PR), and it ran after the file was created; otherwise, it gave me this error, which might or might not be related to the not-building issue.
```
> snrbot@1.0.0 dev
> cross-env NODE_ENV=development tsx watch src/index.ts

sh: cross-env: command not found
```